### PR TITLE
Fixed SlowStartShape Test

### DIFF
--- a/src/atlantis/router/backend/status_test.go
+++ b/src/atlantis/router/backend/status_test.go
@@ -159,7 +159,7 @@ func TestSlowStartShape(t *testing.T) {
 
 	t.Logf("Tdelta, SlowStartFactor")
 	fact := status.SlowStartFactor()
-	for i := 0; i < Tstartup; i++ {
+	for i := 0; i < Tstartup-1; i++ {
 		time.Sleep(1 * time.Second)
 		fact_ := status.SlowStartFactor()
 		t.Logf("%2d, %d", i, fact_)
@@ -168,8 +168,7 @@ func TestSlowStartShape(t *testing.T) {
 		}
 		fact = fact_
 	}
-
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	if status.SlowStartFactor() != 0 {
 		t.Errorf("should be 0 after Tstartup")
 	}


### PR DESCRIPTION
Fix for issue https://github.com/ooyala/atlantis-router/issues/24.

Test `atlantis/router/backend/status_test.go` pass all in 10 occasions in my host machine with `free -m` result showing as:
```
$ free -m
             total       used       free     shared    buffers     cached
Mem:          7893       7089        803        359         44        822
-/+ buffers/cache:       6222       1670
Swap:         8097        855       7242
```
However, **7 times test pass out of 10** in my vagrant guest machine with `free -m` result showing as :
```
$ free -m
             total       used       free     shared    buffers     cached
Mem:          3953       3713        239          1        135       2829
-/+ buffers/cache:        748       3204
Swap:         4095          0       4095
```