### PR TITLE
Changed time format to use 24 hr instead of 12 in HAPROXY log

### DIFF
--- a/src/atlantis/router/logger/httplogger.go
+++ b/src/atlantis/router/logger/httplogger.go
@@ -118,7 +118,7 @@ func (r *HAProxyLogRecord) Log() {
 	//build cookie strings
 	r.capturedReqCookie = getCookiesString(r.Request.Cookies())
 
-	timeFormatted := r.acceptDate.Format("02/Jan/2006:03:04:05.555")
+	timeFormatted := r.acceptDate.Format("02/Jan/2006:15:04:05.555")
 
 	//calculate the queue/wait times
 	r.tt = int64((r.serverResTime.UnixNano() - r.acceptDate.UnixNano()) / int64(time.Millisecond))      // total time from accepted to final response


### PR DESCRIPTION
In the example here: http://golang.org/pkg/time/#Time.Format 

You can see very easily the need for it to be 15 and not 3 for the 24 hour time to work.


Here is a sample log line from the current router:

Sep  9 00:59:59 ip-xx-xx-xx-xx ./bin/atlantis-routerd[xx]: haproxy[xx]: xx.xx.xxx.xxx:33746 [09/Sep/2015:12:59:59.595959]  ..... 

Note the syslog timestamp at front, and the HAPROXY timestamp in the brackets. The syslog one is obviously correct.